### PR TITLE
Added Dockerfile for fleetctl --tunnel

### DIFF
--- a/tunnel/Dockerfile
+++ b/tunnel/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:latest
+
+WORKDIR /root
+
+RUN git clone https://github.com/coreos/fleet.git && \
+  cd fleet && ./build && \
+  cp bin/fleetctl /usr/bin/fleetctl
+
+ADD curl.sh /root/curl.sh
+RUN /root/curl.sh
+ADD run.sh /root/run.sh
+
+ENV S1="fleet.stackone.com"
+ENV S2="fleet.stacktwo.com"
+
+ENTRYPOINT ["/root/run.sh"]

--- a/tunnel/README.md
+++ b/tunnel/README.md
@@ -1,0 +1,15 @@
+# README #
+
+You can only build this project on your local LAN (/VPN).  This is the only way to access private keys not included in source control.
+
+### How to build ###
+* sudo docker build -t fleetctl .
+
+### How to use ###
+* To Submit a Fleet Units: 
+	sudo docker run -v $PWD/unit-files:/root/unit-files fleetctl $S1 start unit-files/service/instances/*  
+* To Destroy a Fleet Units:
+	sudo docker run fleetctl $S1 destroy unit-files/service/instances/*
+
+### Do NOT upload to Docker Hub ###
+### Will contain private keys on build ###

--- a/tunnel/curl.sh
+++ b/tunnel/curl.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# get private keys from LAN storage
+wget 10.22.1.100/stackone.pem
+wget 10.22.1.100/stacktwo.pem
+chmod 0600 stackone.pem
+chmod 0600 stacktwo.pem

--- a/tunnel/run.sh
+++ b/tunnel/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+eval $(ssh-agent -s) > /dev/null
+ssh-add stackone.pem
+ssh-add stacktwo.pem
+
+exec fleetctl --strict-host-key-checking=false --tunnel $*


### PR DESCRIPTION
Thought this is a simple hack might be useful for users looking to run fleetctl without opening a port for the API on any Docker-qualified host.  We pull private keys from a local source, build locally, and create an ssh tunnel to deploy new units from a unit-files repository.
